### PR TITLE
Add note about installation order.

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -40,6 +40,10 @@ the project requirements:
     source env/bin/activate
     pip install -r requirements.txt
 
+(May have to first address Database section below, as `pip install -r
+requirements.txt` may fail looking for `pg_config`.)
+
+
 NOTE: If you run in to trouble with gevent, you can safely comment it out of
 the requirements.txt file.  It is not needed for local development.  To comment
 it out, just add a hash to the beginning of the line for `gevent`.


### PR DESCRIPTION
In documentation, "Local setup" comes before "Database".

However, at least on OS X, running `pip install -r requirements.txt` fails,
mentioning pg_config. But if we execute the steps in the next section titled
"Database", installing postgres etc, the `pip` command succeeds.